### PR TITLE
Fix site documentation links / Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ packages/*/dist
 packages/*/etc
 bin/act
 docs/api
+.DS_Store

--- a/sites/dev/index.html
+++ b/sites/dev/index.html
@@ -94,7 +94,7 @@
             >
             for the implementation and the
             <a
-              href="https://github.com/qgis/qgis-js/blob/main/sites/dev/src/ol.ts#L121"
+              href="https://github.com/qgis/qgis-js/blob/main/sites/dev/src/ol.ts#L130"
               target="_blank"
               class="source"
               >olDemoCanvas-function</a
@@ -157,7 +157,7 @@
             >
             for the implementation and the
             <a
-              href="https://github.com/qgis/qgis-js/blob/main/sites/dev/src/ol.ts#L26"
+              href="https://github.com/qgis/qgis-js/blob/main/sites/dev/src/ol.ts#L28"
               target="_blank"
               class="source"
               >olDemoXYZ-function</a


### PR DESCRIPTION
- Added .DS_Store to .gitignore for MacOS users
- Fixed two links on the demo site that were pointing to wrong line numbers in the code