### PR TITLE
Improve loadRemoteProjects to load relative, absolute and remote projects with any base configuration

### DIFF
--- a/build/vite/DirectoryListingPlugin.ts
+++ b/build/vite/DirectoryListingPlugin.ts
@@ -44,9 +44,14 @@ export default function DirectoryListingPlugin(
           }
           // remove filename from url at the end
           dir = dir.slice(0, -`/${DIRECTORY_LISTING_FILENAME}`.length);
+
+          const dirParts = dir.split("/");
+          const dirBase = dirParts.slice(0, -1).join("/");
+          const dirName = dirParts[dirParts.length - 1];
+
           const drectoryListing = await createDirectoryListing(
-            join(process.cwd(), "public"),
-            dir,
+            join(process.cwd(), "public", dirBase),
+            dirName,
             ".",
           );
           res.setHeader("Content-Type", "application/json");

--- a/packages/qgis-js-utils/src/fs/RemoteProject.ts
+++ b/packages/qgis-js-utils/src/fs/RemoteProject.ts
@@ -4,22 +4,22 @@ import { Project, PROJECTS_UPLOAD_DIR } from "./Project";
 
 import { Folder, flatFolders, flatFiles } from "./FileSystem";
 
-export const REMOTE_PROJECTS_PUBLIC_DIR = "projects";
-
 export class RemoteProject extends Project {
   protected folder: Folder;
   protected path: string;
 
-  constructor(FS: EmscriptenFS, projectFolder: Folder) {
+  private baseUrl: URL;
+
+  constructor(FS: EmscriptenFS, basePath: string, projectFolder: Folder) {
     super(FS, "Remote");
 
+    this.baseUrl = new URL(basePath);
     this.folder = projectFolder;
 
+    const bsaeFolder = this.baseUrl.pathname.split("/").pop();
+
     this.name = projectFolder.name;
-    this.path = projectFolder.path.replace(
-      new RegExp(`^${REMOTE_PROJECTS_PUBLIC_DIR}\/`),
-      "",
-    );
+    this.path = projectFolder.path.replace(new RegExp(`^${bsaeFolder}\/`), "");
   }
 
   getDirectories(): string[] {
@@ -37,7 +37,8 @@ export class RemoteProject extends Project {
         return [
           file,
           new Promise<ArrayBuffer>((resolve, _reject) => {
-            fetch(REMOTE_PROJECTS_PUBLIC_DIR + "/" + file).then((response) =>
+            const remoteUrl = new URL(`${this.baseUrl.href}/${file}`);
+            fetch(remoteUrl).then((response) =>
               response.arrayBuffer().then((buffer) => {
                 resolve(buffer);
               }),


### PR DESCRIPTION
Fix for, and as discussed in, #32 

- Tested with Vite configured with no base, a simple dir as base, and a subdir as base
- Tested with relative `remoteProjects`
  - `projects/directory-listing.json`
  - `./projects/directory-listing.json`
  - `./foo/bar/directory-listing.json`
- Tested with absolute `remoteProjects`
  - `/base/projects/directory-listing.json`
  - `/base/with/sub/foo/bar/directory-listing.json`
- Tested with full URLs as `remoteProjects`
  - https://some.server/foo/bar/directory-listing.json