### PR TITLE
API: Expose layer features and identify requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ This document describes changes between tagged qgis-js versions
   - Enables rendering subsets of layers and composing multiple OL layers from different QGIS layer groups.
   - All three OL data sources (`QgisCanvasDataSource`, `QgisXYZDataSource`, `QgisJobDataSource`) accept `layerIds` in options.
 - Added `loadLayerDefinition()` to load .qlr files at runtime into the project layer tree. (#59)
+- Added feature inspection API faithful to the QGIS C++ API.
+  - `QgsFeature` with `id()`, `isValid()`, `hasGeometry()`, `geometry()`, `fields()`, `attributes()`, `attribute(name|index)`, `attributeCount()`.
+  - `QgsGeometry` with `isNull()`, `isEmpty()`, `wkbType()`, `asWkb()` (owned `Uint8Array`), `asWkt(precision)`, `asJson(precision)`.
+  - `QgsFields` / `QgsField` for layer schema introspection.
+  - `QgsFeatureIterator` with `nextFeature()` (returns the feature or `null`), `rewind()`, `close()`, `isClosed()`, `isValid()` for lazy iteration over large layers.
+  - `QgsFeatureRequest` with `setFilterRect`, `setFilterExpression`, `setFilterFid(s)`, `setLimit`, `setFlags`, `setSubsetOfAttributes`, `setDestinationCrs` — and a `FeatureRequestFlag` enum mirroring `Qgis::FeatureRequestFlag`.
+  - `QgsVectorLayer` extended with `featureCount()`, `fields()`, `getFeatures(request?)`.
+  - `QgsMapLayer.crs()` returns the layer's source SRID authid.
+- Added cross-layer identify: `api.identify(rect, rectSrid, mode)` plus an `IdentifyMode` enum (`TopDownStopAtFirst`, `TopDownAll`). Re-implements the core of `QgsMapToolIdentify::identifyVectorLayer` without pulling in `qgis_gui`.
+- Added `qgis-js-example-features` to `docs/examples/`: paginated feature table, attribute identify on map click, view-extent filter, and per-feature highlight on OpenLayers.
 
 ## 4.0.0 (16. March 2026)
 

--- a/docs/examples/qgis-js-example-features/index.html
+++ b/docs/examples/qgis-js-example-features/index.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>qgis-js-example-features</title>
+    <link rel="icon" href="data:," />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div id="app">
+      <div id="top">
+        <aside>
+          <h3>Layer</h3>
+          <select id="layer-select"></select>
+          <p id="summary"></p>
+          <h3>Fields</h3>
+          <table id="fields-table">
+            <thead>
+              <tr>
+                <th>name</th>
+                <th>type</th>
+                <th>length</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </aside>
+        <div id="map"></div>
+        <aside id="identify">
+          <h3>Identify</h3>
+          <p id="identify-summary">Click the map to identify features</p>
+          <div id="identify-list"></div>
+        </aside>
+      </div>
+      <div id="bottom">
+        <h3>Features</h3>
+        <div class="actions">
+          <button id="load-more">Load more (50)</button>
+          <button id="filter-by-view">Filter by current view</button>
+          <button id="reset">Reset filter</button>
+        </div>
+        <div class="features-scroll">
+          <table id="features-table">
+            <thead>
+              <tr></tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <template id="identify-card-template">
+      <div class="identify-card">
+        <div class="identify-card-header"></div>
+        <table>
+          <tbody></tbody>
+        </table>
+      </div>
+    </template>
+    <script type="module" src="main.js"></script>
+  </body>
+</html>

--- a/docs/examples/qgis-js-example-features/index.html
+++ b/docs/examples/qgis-js-example-features/index.html
@@ -28,6 +28,10 @@
         <div id="map"></div>
         <aside id="identify">
           <h3>Identify</h3>
+          <label class="inline">
+            Hit box (px):
+            <input id="hit-box" type="number" min="1" max="50" value="5" />
+          </label>
           <p id="identify-summary">Click the map to identify features</p>
           <div id="identify-list"></div>
         </aside>
@@ -35,9 +39,19 @@
       <div id="bottom">
         <h3>Features</h3>
         <div class="actions">
-          <button id="load-more">Load more (50)</button>
           <button id="filter-by-view">Filter by current view</button>
-          <button id="reset">Reset filter</button>
+          <button id="reset" disabled>Reset filter</button>
+          <label class="inline">
+            Page size:
+            <select id="page-size">
+              <option value="10">10</option>
+              <option value="25">25</option>
+              <option value="50" selected>50</option>
+              <option value="100">100</option>
+              <option value="200">200</option>
+            </select>
+          </label>
+          <nav id="pagination"></nav>
         </div>
         <div class="features-scroll">
           <table id="features-table">
@@ -49,10 +63,16 @@
         </div>
       </div>
     </div>
+    <div id="popup"></div>
     <template id="identify-card-template">
       <div class="identify-card">
-        <div class="identify-card-header"></div>
         <table>
+          <thead>
+            <tr>
+              <th>Field</th>
+              <th>Value</th>
+            </tr>
+          </thead>
           <tbody></tbody>
         </table>
       </div>

--- a/docs/examples/qgis-js-example-features/main.js
+++ b/docs/examples/qgis-js-example-features/main.js
@@ -5,13 +5,10 @@ import ImageLayer from "ol/layer/Image";
 import VectorLayer from "ol/layer/Vector";
 import VectorSource from "ol/source/Vector";
 import Feature from "ol/Feature";
+import Overlay from "ol/Overlay";
 import Projection from "ol/proj/Projection.js";
 import WKB from "ol/format/WKB";
 import { Style, Stroke, Fill, Circle as CircleStyle } from "ol/style";
-
-const PAGE_SIZE = 50;
-const HIT_BOX_PIXELS = 5;
-const IDLE_IDENTIFY_TEXT = "Click the map to identify features";
 
 const cssColor = (name) => {
   const probe = document.body.appendChild(document.createElement("div"));
@@ -32,17 +29,21 @@ const projectFiles = ["project.qgz", "world_map.gpkg"];
 await Promise.all(
   projectFiles.map(async (file) => {
     const response = await fetch(`${projectSource}/${file}`);
+    if (!response.ok)
+      throw new Error(`Failed to fetch ${file}: ${response.status}`);
     fs.writeFile(
       `${uploadDir}/${file}`,
       new Uint8Array(await response.arrayBuffer()),
     );
   }),
 );
-api.loadProject(`${uploadDir}/${projectFiles[0]}`);
+if (!api.loadProject(`${uploadDir}/${projectFiles[0]}`)) {
+  throw new Error(`loadProject failed for ${projectFiles[0]}`);
+}
 
 const projection = new Projection({ code: api.srid(), units: "m" });
 
-const highlightStyle = new Style({
+const primaryStyle = new Style({
   stroke: new Stroke({ color: cssColor("--color-highlight-stroke"), width: 3 }),
   fill: new Fill({ color: cssColor("--color-highlight-fill") }),
   image: new CircleStyle({
@@ -54,13 +55,23 @@ const highlightStyle = new Style({
     fill: new Fill({ color: cssColor("--color-highlight-marker-fill") }),
   }),
 });
-const highlightSource = new VectorSource();
+const secondaryStyle = new Style({
+  stroke: new Stroke({
+    color: cssColor("--color-highlight-secondary-stroke"),
+    width: 1.5,
+  }),
+  fill: new Fill({ color: cssColor("--color-highlight-secondary-fill") }),
+});
+
+const primarySource = new VectorSource();
+const secondarySource = new VectorSource();
 
 const map = new Map({
   target: "map",
   layers: [
     new ImageLayer({ source: new QgisCanvasDataSource(api, { projection }) }),
-    new VectorLayer({ source: highlightSource, style: highlightStyle }),
+    new VectorLayer({ source: secondarySource, style: secondaryStyle }),
+    new VectorLayer({ source: primarySource, style: primaryStyle }),
   ],
   view: new View({ center: [0, 0], zoom: 2, projection }),
 });
@@ -73,12 +84,24 @@ const summary = el("#summary");
 const fieldsBody = el("#fields-table tbody");
 const featuresHead = el("#features-table thead tr");
 const featuresBody = el("#features-table tbody");
-const loadMoreBtn = el("#load-more");
 const filterBtn = el("#filter-by-view");
 const resetBtn = el("#reset");
+const pageSizeSelect = el("#page-size");
+const paginationEl = el("#pagination");
+const hitBoxInput = el("#hit-box");
 const identifySummary = el("#identify-summary");
 const identifyList = el("#identify-list");
 const identifyCardTemplate = el("#identify-card-template");
+const popupEl = el("#popup");
+const idleIdentifyText = identifySummary.textContent;
+
+const popup = new Overlay({
+  element: popupEl,
+  positioning: "bottom-center",
+  offset: [0, -10],
+  stopEvent: false,
+});
+map.addOverlay(popup);
 
 const vectorLayers = collectVectorLayers(api.layerTreeRoot());
 layerSelect.replaceChildren(
@@ -92,15 +115,20 @@ layerSelect.replaceChildren(
 
 let currentLayer = null;
 let currentFieldNames = [];
-let currentIterator = null;
-let loadedCount = 0;
+let currentFeatures = [];
+let currentPage = 1;
+let pageSize = Number(pageSizeSelect.value);
 
 layerSelect.addEventListener("change", () =>
   openLayer(findLayer(layerSelect.value)),
 );
-loadMoreBtn.addEventListener("click", loadMore);
 filterBtn.addEventListener("click", () => applyFilter(true));
 resetBtn.addEventListener("click", () => applyFilter(false));
+pageSizeSelect.addEventListener("change", () => {
+  pageSize = Number(pageSizeSelect.value);
+  currentPage = 1;
+  renderPage();
+});
 map.on("singleclick", (event) => identifyAt(event.coordinate));
 
 if (vectorLayers.length) {
@@ -126,11 +154,11 @@ function findLayer(id) {
 }
 
 function openLayer(layer) {
-  closeIterator();
   currentLayer = layer;
-  highlightSource.clear();
+  clearHighlight();
   clearTableSelection();
   clearIdentify();
+  resetBtn.disabled = true;
   if (!layer) return;
 
   const fields = fieldArray(layer.fields());
@@ -140,12 +168,9 @@ function openLayer(layer) {
     ...fields.map((f) => makeRow([f.name(), f.typeName(), String(f.length())])),
   );
   rebuildFeaturesHeader();
-  featuresBody.replaceChildren();
 
   summary.textContent = `${layer.featureCount()} features total`;
-  loadedCount = 0;
-  currentIterator = layer.getFeatures(featureRequest());
-  loadMore();
+  loadFeatures(featureRequest());
 }
 
 function fieldArray(fields) {
@@ -168,29 +193,20 @@ function rebuildFeaturesHeader() {
   );
 }
 
-function closeIterator() {
-  currentIterator?.close();
-  currentIterator = null;
+function loadFeatures(request) {
+  currentFeatures = drain(currentLayer.getFeatures(request));
+  currentPage = 1;
+  renderPage();
 }
 
-function loadMore() {
-  if (!currentIterator) return;
-  let added = 0;
-  while (added < PAGE_SIZE) {
-    const feature = currentIterator.nextFeature();
-    if (!feature) {
-      loadMoreBtn.disabled = true;
-      loadMoreBtn.textContent = `End of features — ${loadedCount} loaded`;
-      return;
-    }
-    appendFeatureRow(feature);
-    loadedCount++;
-    added++;
-  }
-  loadMoreBtn.textContent = `Load more (${PAGE_SIZE}) — ${loadedCount} loaded`;
+function renderPage() {
+  const start = (currentPage - 1) * pageSize;
+  const slice = currentFeatures.slice(start, start + pageSize);
+  featuresBody.replaceChildren(...slice.map(makeFeatureRow));
+  renderPagination();
 }
 
-function appendFeatureRow(feature) {
+function makeFeatureRow(feature) {
   const row = makeRow([feature.id(), ...feature.attributes()].map(formatCell));
   row.addEventListener("click", () => {
     clearTableSelection();
@@ -198,14 +214,52 @@ function appendFeatureRow(feature) {
     clearIdentify();
     highlightFeature(feature);
   });
-  featuresBody.appendChild(row);
+  return row;
+}
+
+function renderPagination() {
+  const totalPages = Math.max(1, Math.ceil(currentFeatures.length / pageSize));
+  if (totalPages <= 1) {
+    paginationEl.replaceChildren();
+    return;
+  }
+  paginationEl.replaceChildren(
+    pageBtn("‹", currentPage > 1 ? currentPage - 1 : null),
+    ...paginationPages(currentPage, totalPages).map((p) =>
+      p === null
+        ? pageBtn("…", null)
+        : pageBtn(String(p), p, p === currentPage),
+    ),
+    pageBtn("›", currentPage < totalPages ? currentPage + 1 : null),
+  );
+}
+
+function paginationPages(current, total) {
+  if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
+  if (current <= 4) return [1, 2, 3, 4, 5, null, total];
+  if (current >= total - 3)
+    return [1, null, total - 4, total - 3, total - 2, total - 1, total];
+  return [1, null, current - 1, current, current + 1, null, total];
+}
+
+function pageBtn(label, target, isCurrent = false) {
+  const b = document.createElement("button");
+  b.textContent = label;
+  b.classList.toggle("current", isCurrent);
+  b.disabled = target === null;
+  if (target !== null)
+    b.addEventListener("click", () => {
+      currentPage = target;
+      renderPage();
+    });
+  return b;
 }
 
 function highlightFeature(feature) {
-  highlightSource.clear();
+  clearHighlight();
   if (!feature.hasGeometry()) return;
   const geom = wkbFormat.readGeometry(feature.geometry().asWkb());
-  highlightSource.addFeature(new Feature({ geometry: geom }));
+  primarySource.addFeature(new Feature({ geometry: geom }));
   const extent = geom.getExtent();
   if (Number.isFinite(extent[0])) {
     map.getView().fit(extent, { padding: [40, 40, 40, 40], maxZoom: 10 });
@@ -214,12 +268,6 @@ function highlightFeature(feature) {
 
 function applyFilter(useView) {
   if (!currentLayer) return;
-  closeIterator();
-  featuresBody.replaceChildren();
-  loadedCount = 0;
-  loadMoreBtn.disabled = false;
-  loadMoreBtn.textContent = `Load more (${PAGE_SIZE})`;
-
   const request = featureRequest();
   if (useView) {
     const [xmin, ymin, xmax, ymax] = map
@@ -227,18 +275,20 @@ function applyFilter(useView) {
       .calculateExtent(map.getSize());
     request.setFilterRect(new api.QgsRectangle(xmin, ymin, xmax, ymax));
     summary.textContent = "Filtered to current map view";
+    resetBtn.disabled = false;
   } else {
     summary.textContent = `${currentLayer.featureCount()} features total`;
+    resetBtn.disabled = true;
   }
-  currentIterator = currentLayer.getFeatures(request);
-  loadMore();
+  loadFeatures(request);
 }
 
 function identifyAt([x, y]) {
   if (!currentLayer) return;
   clearTableSelection();
 
-  const radius = map.getView().getResolution() * HIT_BOX_PIXELS;
+  const pixels = Math.max(1, Number(hitBoxInput.value) || 1);
+  const radius = map.getView().getResolution() * pixels;
   const request = featureRequest();
   request.setFilterRect(
     new api.QgsRectangle(x - radius, y - radius, x + radius, y + radius),
@@ -246,14 +296,28 @@ function identifyAt([x, y]) {
   request.setFlags(FeatureRequestFlag.ExactIntersect);
 
   const hits = drain(currentLayer.getFeatures(request));
-  highlightSource.clear();
-  for (const hit of hits) {
-    if (!hit.hasGeometry()) continue;
-    highlightSource.addFeature(
-      new Feature({ geometry: wkbFormat.readGeometry(hit.geometry().asWkb()) }),
-    );
-  }
+  clearHighlight();
+  hits.forEach((hit, i) => {
+    if (!hit.hasGeometry()) return;
+    const f = new Feature({
+      geometry: wkbFormat.readGeometry(hit.geometry().asWkb()),
+    });
+    (i === 0 ? primarySource : secondarySource).addFeature(f);
+  });
   renderIdentify(hits);
+  showMapTip(hits[0], [x, y]);
+}
+
+function showMapTip(feature, position) {
+  const tip = feature && currentLayer.mapTipTemplate();
+  if (!tip) {
+    popup.setPosition(undefined);
+    return;
+  }
+  const ctx = currentLayer.createExpressionContext();
+  ctx.setFeature(feature);
+  popupEl.innerHTML = api.QgsExpression.replaceExpressionText(tip, ctx);
+  popup.setPosition(position);
 }
 
 function drain(it) {
@@ -276,8 +340,6 @@ function renderIdentify(features) {
 
 function renderIdentifyCard(feature) {
   const card = identifyCardTemplate.content.firstElementChild.cloneNode(true);
-  card.querySelector(".identify-card-header").textContent =
-    `Feature ${feature.id()}`;
   const attrs = feature.attributes();
   card
     .querySelector("tbody")
@@ -293,9 +355,15 @@ function clearTableSelection() {
   featuresBody.querySelector(".selected")?.classList.remove("selected");
 }
 
+function clearHighlight() {
+  primarySource.clear();
+  secondarySource.clear();
+}
+
 function clearIdentify() {
   identifyList.replaceChildren();
-  identifySummary.textContent = IDLE_IDENTIFY_TEXT;
+  identifySummary.textContent = idleIdentifyText;
+  popup.setPosition(undefined);
 }
 
 function makeRow(cells) {

--- a/docs/examples/qgis-js-example-features/main.js
+++ b/docs/examples/qgis-js-example-features/main.js
@@ -1,0 +1,314 @@
+import { qgis, LayerType, FeatureRequestFlag } from "qgis-js";
+import { QgisCanvasDataSource } from "@qgis-js/ol";
+import { Map, View } from "ol";
+import ImageLayer from "ol/layer/Image";
+import VectorLayer from "ol/layer/Vector";
+import VectorSource from "ol/source/Vector";
+import Feature from "ol/Feature";
+import Projection from "ol/proj/Projection.js";
+import WKB from "ol/format/WKB";
+import { Style, Stroke, Fill, Circle as CircleStyle } from "ol/style";
+
+const PAGE_SIZE = 50;
+const HIT_BOX_PIXELS = 5;
+const IDLE_IDENTIFY_TEXT = "Click the map to identify features";
+
+const cssColor = (name) => {
+  const probe = document.body.appendChild(document.createElement("div"));
+  probe.style.color = `var(${name})`;
+  const value = getComputedStyle(probe).color;
+  probe.remove();
+  return value;
+};
+
+const { api, fs } = await qgis({ prefix: "/assets/wasm" });
+
+const uploadDir = "/upload";
+fs.mkdir(uploadDir);
+
+const projectSource =
+  "https://raw.githubusercontent.com/boardend/qgis-js-projects/main/demo/World%20GPKG";
+const projectFiles = ["project.qgz", "world_map.gpkg"];
+await Promise.all(
+  projectFiles.map(async (file) => {
+    const response = await fetch(`${projectSource}/${file}`);
+    fs.writeFile(
+      `${uploadDir}/${file}`,
+      new Uint8Array(await response.arrayBuffer()),
+    );
+  }),
+);
+api.loadProject(`${uploadDir}/${projectFiles[0]}`);
+
+const projection = new Projection({ code: api.srid(), units: "m" });
+
+const highlightStyle = new Style({
+  stroke: new Stroke({ color: cssColor("--color-highlight-stroke"), width: 3 }),
+  fill: new Fill({ color: cssColor("--color-highlight-fill") }),
+  image: new CircleStyle({
+    radius: 6,
+    stroke: new Stroke({
+      color: cssColor("--color-highlight-stroke"),
+      width: 2,
+    }),
+    fill: new Fill({ color: cssColor("--color-highlight-marker-fill") }),
+  }),
+});
+const highlightSource = new VectorSource();
+
+const map = new Map({
+  target: "map",
+  layers: [
+    new ImageLayer({ source: new QgisCanvasDataSource(api, { projection }) }),
+    new VectorLayer({ source: highlightSource, style: highlightStyle }),
+  ],
+  view: new View({ center: [0, 0], zoom: 2, projection }),
+});
+
+const wkbFormat = new WKB();
+
+const el = (sel) => document.querySelector(sel);
+const layerSelect = el("#layer-select");
+const summary = el("#summary");
+const fieldsBody = el("#fields-table tbody");
+const featuresHead = el("#features-table thead tr");
+const featuresBody = el("#features-table tbody");
+const loadMoreBtn = el("#load-more");
+const filterBtn = el("#filter-by-view");
+const resetBtn = el("#reset");
+const identifySummary = el("#identify-summary");
+const identifyList = el("#identify-list");
+const identifyCardTemplate = el("#identify-card-template");
+
+const vectorLayers = collectVectorLayers(api.layerTreeRoot());
+layerSelect.replaceChildren(
+  ...vectorLayers.map((layer) => {
+    const opt = document.createElement("option");
+    opt.value = layer.id();
+    opt.textContent = layer.name;
+    return opt;
+  }),
+);
+
+let currentLayer = null;
+let currentFieldNames = [];
+let currentIterator = null;
+let loadedCount = 0;
+
+layerSelect.addEventListener("change", () =>
+  openLayer(findLayer(layerSelect.value)),
+);
+loadMoreBtn.addEventListener("click", loadMore);
+filterBtn.addEventListener("click", () => applyFilter(true));
+resetBtn.addEventListener("click", () => applyFilter(false));
+map.on("singleclick", (event) => identifyAt(event.coordinate));
+
+if (vectorLayers.length) {
+  layerSelect.value = vectorLayers[0].id();
+  openLayer(vectorLayers[0]);
+}
+
+function collectVectorLayers(group) {
+  const result = [];
+  for (const child of group.children()) {
+    if (child.isGroup()) {
+      result.push(...collectVectorLayers(child));
+    } else if (child.isLayer()) {
+      const layer = child.layer();
+      if (layer?.type() === LayerType.Vector) result.push(layer);
+    }
+  }
+  return result;
+}
+
+function findLayer(id) {
+  return vectorLayers.find((l) => l.id() === id) ?? null;
+}
+
+function openLayer(layer) {
+  closeIterator();
+  currentLayer = layer;
+  highlightSource.clear();
+  clearTableSelection();
+  clearIdentify();
+  if (!layer) return;
+
+  const fields = fieldArray(layer.fields());
+  currentFieldNames = fields.map((f) => f.name());
+
+  fieldsBody.replaceChildren(
+    ...fields.map((f) => makeRow([f.name(), f.typeName(), String(f.length())])),
+  );
+  rebuildFeaturesHeader();
+  featuresBody.replaceChildren();
+
+  summary.textContent = `${layer.featureCount()} features total`;
+  loadedCount = 0;
+  currentIterator = layer.getFeatures(featureRequest());
+  loadMore();
+}
+
+function fieldArray(fields) {
+  return Array.from({ length: fields.count() }, (_, i) => fields.at(i));
+}
+
+function featureRequest() {
+  const r = new api.QgsFeatureRequest();
+  r.setDestinationCrs(projection.getCode());
+  return r;
+}
+
+function rebuildFeaturesHeader() {
+  featuresHead.replaceChildren(
+    ...["id", ...currentFieldNames].map((name) => {
+      const th = document.createElement("th");
+      th.textContent = name;
+      return th;
+    }),
+  );
+}
+
+function closeIterator() {
+  currentIterator?.close();
+  currentIterator = null;
+}
+
+function loadMore() {
+  if (!currentIterator) return;
+  let added = 0;
+  while (added < PAGE_SIZE) {
+    const feature = currentIterator.nextFeature();
+    if (!feature) {
+      loadMoreBtn.disabled = true;
+      loadMoreBtn.textContent = `End of features — ${loadedCount} loaded`;
+      return;
+    }
+    appendFeatureRow(feature);
+    loadedCount++;
+    added++;
+  }
+  loadMoreBtn.textContent = `Load more (${PAGE_SIZE}) — ${loadedCount} loaded`;
+}
+
+function appendFeatureRow(feature) {
+  const row = makeRow([feature.id(), ...feature.attributes()].map(formatCell));
+  row.addEventListener("click", () => {
+    clearTableSelection();
+    row.classList.add("selected");
+    clearIdentify();
+    highlightFeature(feature);
+  });
+  featuresBody.appendChild(row);
+}
+
+function highlightFeature(feature) {
+  highlightSource.clear();
+  if (!feature.hasGeometry()) return;
+  const geom = wkbFormat.readGeometry(feature.geometry().asWkb());
+  highlightSource.addFeature(new Feature({ geometry: geom }));
+  const extent = geom.getExtent();
+  if (Number.isFinite(extent[0])) {
+    map.getView().fit(extent, { padding: [40, 40, 40, 40], maxZoom: 10 });
+  }
+}
+
+function applyFilter(useView) {
+  if (!currentLayer) return;
+  closeIterator();
+  featuresBody.replaceChildren();
+  loadedCount = 0;
+  loadMoreBtn.disabled = false;
+  loadMoreBtn.textContent = `Load more (${PAGE_SIZE})`;
+
+  const request = featureRequest();
+  if (useView) {
+    const [xmin, ymin, xmax, ymax] = map
+      .getView()
+      .calculateExtent(map.getSize());
+    request.setFilterRect(new api.QgsRectangle(xmin, ymin, xmax, ymax));
+    summary.textContent = "Filtered to current map view";
+  } else {
+    summary.textContent = `${currentLayer.featureCount()} features total`;
+  }
+  currentIterator = currentLayer.getFeatures(request);
+  loadMore();
+}
+
+function identifyAt([x, y]) {
+  if (!currentLayer) return;
+  clearTableSelection();
+
+  const radius = map.getView().getResolution() * HIT_BOX_PIXELS;
+  const request = featureRequest();
+  request.setFilterRect(
+    new api.QgsRectangle(x - radius, y - radius, x + radius, y + radius),
+  );
+  request.setFlags(FeatureRequestFlag.ExactIntersect);
+
+  const hits = drain(currentLayer.getFeatures(request));
+  highlightSource.clear();
+  for (const hit of hits) {
+    if (!hit.hasGeometry()) continue;
+    highlightSource.addFeature(
+      new Feature({ geometry: wkbFormat.readGeometry(hit.geometry().asWkb()) }),
+    );
+  }
+  renderIdentify(hits);
+}
+
+function drain(it) {
+  const out = [];
+  let f;
+  while ((f = it.nextFeature())) out.push(f);
+  it.close();
+  return out;
+}
+
+function renderIdentify(features) {
+  identifyList.replaceChildren();
+  if (!features.length) {
+    identifySummary.textContent = "Nothing identified here";
+    return;
+  }
+  identifySummary.textContent = `${features.length} feature${features.length === 1 ? "" : "s"} in ${currentLayer.name}`;
+  identifyList.append(...features.map(renderIdentifyCard));
+}
+
+function renderIdentifyCard(feature) {
+  const card = identifyCardTemplate.content.firstElementChild.cloneNode(true);
+  card.querySelector(".identify-card-header").textContent =
+    `Feature ${feature.id()}`;
+  const attrs = feature.attributes();
+  card
+    .querySelector("tbody")
+    .replaceChildren(
+      ...currentFieldNames.map((name, i) =>
+        makeRow([name, formatCell(attrs[i])]),
+      ),
+    );
+  return card;
+}
+
+function clearTableSelection() {
+  featuresBody.querySelector(".selected")?.classList.remove("selected");
+}
+
+function clearIdentify() {
+  identifyList.replaceChildren();
+  identifySummary.textContent = IDLE_IDENTIFY_TEXT;
+}
+
+function makeRow(cells) {
+  const row = document.createElement("tr");
+  for (const text of cells) {
+    const td = document.createElement("td");
+    td.textContent = text;
+    td.title = text;
+    row.appendChild(td);
+  }
+  return row;
+}
+
+function formatCell(v) {
+  return v == null ? "" : String(v);
+}

--- a/docs/examples/qgis-js-example-features/package.json
+++ b/docs/examples/qgis-js-example-features/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "qgis-js-example-features",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "ol": "^10.8.0",
+    "@qgis-js/ol": "file:../../../packages/qgis-js-ol",
+    "qgis-js": "file:../../../packages/qgis-js"
+  },
+  "devDependencies": {
+    "vite": "^8.0.0",
+    "vite-plugin-static-copy": "^3.2.0"
+  }
+}

--- a/docs/examples/qgis-js-example-features/style.css
+++ b/docs/examples/qgis-js-example-features/style.css
@@ -1,0 +1,162 @@
+@import "node_modules/ol/ol.css";
+
+:root {
+  --qgis: #589632;
+
+  --color-border: color-mix(in srgb, var(--qgis) 30%, white);
+  --color-row-divider: color-mix(in srgb, var(--qgis) 10%, white);
+  --color-thead-bg: color-mix(in srgb, var(--qgis) 5%, white);
+  --color-thead-border: color-mix(in srgb, var(--qgis) 25%, white);
+  --color-row-hover: color-mix(in srgb, var(--qgis) 10%, white);
+  --color-row-selected: color-mix(in srgb, var(--qgis) 30%, white);
+  --color-highlight-stroke: var(--qgis);
+  --color-highlight-fill: color-mix(in srgb, var(--qgis) 20%, transparent);
+  --color-highlight-marker-fill: color-mix(
+    in srgb,
+    var(--qgis) 40%,
+    transparent
+  );
+
+  --gap: 1rem;
+  --pad: 0.75rem;
+  --side-col: 20rem;
+  --cell-max: 10rem;
+  --hairline: 1px;
+
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-size-panel: 0.8125rem;
+  --font-size-table: 0.75rem;
+}
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+body {
+  font-family: sans-serif;
+}
+
+#app {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap);
+  height: 100vh;
+  padding: var(--gap);
+  box-sizing: border-box;
+}
+
+#top {
+  display: grid;
+  grid-template-columns: var(--side-col) 1fr var(--side-col);
+  gap: var(--gap);
+  flex: 1 1 50%;
+  min-height: 0;
+}
+
+#bottom {
+  flex: 1 1 50%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+aside,
+#map,
+#bottom {
+  border: var(--hairline) solid var(--color-border);
+  box-sizing: border-box;
+}
+
+aside,
+#bottom {
+  padding: var(--pad);
+  font-size: var(--font-size-panel);
+}
+
+aside {
+  overflow: auto;
+}
+
+:where(aside, #bottom) h3 {
+  margin: 1em 0 0.25em;
+}
+
+:where(aside, #bottom) h3:first-child {
+  margin-top: 0;
+}
+
+table {
+  border-collapse: collapse;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-table);
+}
+
+th,
+td {
+  text-align: left;
+  padding: 0.2em 0.4em;
+  vertical-align: top;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  background: var(--color-thead-bg);
+  border-bottom: var(--hairline) solid var(--color-thead-border);
+  z-index: 1;
+}
+
+tbody td {
+  border-bottom: var(--hairline) solid var(--color-row-divider);
+  white-space: nowrap;
+  max-width: var(--cell-max);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.features-scroll {
+  overflow: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.identify-card {
+  margin-bottom: 0.5em;
+}
+
+.identify-card-header {
+  font-weight: bold;
+  font-size: var(--font-size-table);
+  font-family: var(--font-mono);
+  margin-bottom: 0.25em;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  margin: 0.5em 0;
+  flex-wrap: wrap;
+}
+
+button {
+  font-size: var(--font-size-table);
+  padding: 0.4em 0.8em;
+  cursor: pointer;
+}
+
+#features-table tbody tr {
+  cursor: pointer;
+}
+
+#features-table tbody tr:hover {
+  background: var(--color-row-hover);
+}
+
+#features-table tbody tr.selected {
+  background: var(--color-row-selected);
+}

--- a/docs/examples/qgis-js-example-features/style.css
+++ b/docs/examples/qgis-js-example-features/style.css
@@ -16,6 +16,16 @@
     var(--qgis) 40%,
     transparent
   );
+  --color-highlight-secondary-stroke: color-mix(
+    in srgb,
+    var(--qgis) 50%,
+    transparent
+  );
+  --color-highlight-secondary-fill: color-mix(
+    in srgb,
+    var(--qgis) 8%,
+    transparent
+  );
 
   --gap: 1rem;
   --pad: 0.75rem;
@@ -91,6 +101,7 @@ aside {
 
 table {
   border-collapse: collapse;
+  width: 100%;
   font-family: var(--font-mono);
   font-size: var(--font-size-table);
 }
@@ -128,11 +139,14 @@ tbody td {
   margin-bottom: 0.5em;
 }
 
-.identify-card-header {
-  font-weight: bold;
-  font-size: var(--font-size-table);
-  font-family: var(--font-mono);
-  margin-bottom: 0.25em;
+#popup {
+  background: white;
+  border: var(--hairline) solid var(--color-border);
+  border-radius: 0.25rem;
+  padding: var(--pad);
+  max-width: 20rem;
+  box-shadow: 0 0.1rem 0.3rem rgb(0 0 0 / 0.15);
+  font-size: var(--font-size-panel);
 }
 
 .actions {
@@ -143,10 +157,42 @@ tbody td {
   flex-wrap: wrap;
 }
 
+.inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25em;
+}
+
+input[type="number"] {
+  font: inherit;
+  width: 4em;
+  padding: 0.2em 0.4em;
+}
+
 button {
   font-size: var(--font-size-table);
   padding: 0.4em 0.8em;
   cursor: pointer;
+}
+
+#pagination {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25em;
+  margin-left: auto;
+}
+
+#pagination button {
+  min-width: 2em;
+}
+
+#pagination button.current {
+  background: var(--color-row-selected);
+  font-weight: bold;
+}
+
+.identify-card thead th {
+  position: static;
 }
 
 #features-table tbody tr {

--- a/docs/examples/qgis-js-example-features/vite.config.js
+++ b/docs/examples/qgis-js-example-features/vite.config.js
@@ -1,0 +1,39 @@
+import { defineConfig } from "vite";
+
+import { viteStaticCopy } from "vite-plugin-static-copy";
+
+const headers = {
+  "Cross-Origin-Opener-Policy": "same-origin",
+  "Cross-Origin-Embedder-Policy": "require-corp",
+};
+
+export default defineConfig({
+  build: {
+    target: "esnext",
+  },
+  plugins: [
+    {
+      name: "headers-after-static-copy",
+      configureServer(server) {
+        server.middlewares.use((_req, res, next) => {
+          Object.entries(headers).forEach(([key, value]) => {
+            res.setHeader(key, value);
+          });
+          next();
+        });
+      },
+    },
+    viteStaticCopy({
+      silent: true,
+      targets: [
+        {
+          src: "node_modules/qgis-js/dist/assets/wasm/**",
+          dest: "assets/wasm",
+        },
+      ],
+    }),
+  ],
+  preview: {
+    headers,
+  },
+});

--- a/packages/qgis-js/src/index.ts
+++ b/packages/qgis-js/src/index.ts
@@ -30,6 +30,8 @@ export type {
   QgsFeature,
   QgsFeatureIterator,
   QgsFeatureRequest,
+  QgsExpression,
+  QgsExpressionContext,
 } from "../../../src/api/QgisModel";
 
 export {

--- a/packages/qgis-js/src/index.ts
+++ b/packages/qgis-js/src/index.ts
@@ -24,8 +24,21 @@ export type {
   QgsLayerTreeLayer,
   QgsMapLayer,
   QgsVectorLayer,
+  QgsField,
+  QgsFields,
+  QgsGeometry,
+  QgsFeature,
+  QgsFeatureIterator,
+  QgsFeatureRequest,
 } from "../../../src/api/QgisModel";
 
-export { LayerType, NodeType } from "../../../src/api/QgisModel";
+export {
+  LayerType,
+  NodeType,
+  FeatureRequestFlag,
+  IdentifyMode,
+} from "../../../src/api/QgisModel";
+
+export type { IdentifyResult } from "../../../src/api/QgisModel";
 
 export { qgis } from "./loader";

--- a/src/api/QgisApi.cpp
+++ b/src/api/QgisApi.cpp
@@ -17,6 +17,8 @@
 #include <QString>
 #include <QtConcurrent/QtConcurrent>
 
+#include "../model/QgsExpression.hpp"
+#include "../model/QgsExpressionContext.hpp"
 #include "../model/QgsFeature.hpp"
 #include "../model/QgsFeatureRequest.hpp"
 #include "../model/QgsLayerTreeLayer.hpp"

--- a/src/api/QgisApi.cpp
+++ b/src/api/QgisApi.cpp
@@ -17,6 +17,8 @@
 #include <QString>
 #include <QtConcurrent/QtConcurrent>
 
+#include "../model/QgsFeature.hpp"
+#include "../model/QgsFeatureRequest.hpp"
 #include "../model/QgsLayerTreeLayer.hpp"
 #include "../model/QgsMapRendererJob.hpp"
 #include "../model/QgsMapRendererParallelJob.hpp"
@@ -336,6 +338,52 @@ struct LayerDefinitionResult {
   std::string errorMessage;
 };
 
+// Identify mode mirrors the relevant subset of QgsMapToolIdentify::IdentifyMode.
+// We deliberately only ship the top-down modes (and we don't pull in qgis_gui).
+//   TopDownStopAtFirst = 0: walk visible layers top-down, return after the
+//                           first layer that yields any hits.
+//   TopDownAll         = 1: walk all visible layers top-down, return every hit.
+emscripten::val QgisApi_identify(const QgsRectangle &rect, std::string rectSrid, int mode) {
+  emscripten::val results = emscripten::val::array();
+
+  QgsCoordinateReferenceSystem rectCrs(QString::fromStdString(rectSrid));
+  const QgsCoordinateTransformContext &transformContext =
+    QgsProject::instance()->transformContext();
+
+  // QgisApi_visibleLayers() returns visible layers in render order; the first
+  // entry is the topmost layer in the layer tree.
+  const QList<QgsMapLayer *> layers = QgisApi_visibleLayers();
+
+  for (QgsMapLayer *layer : layers) {
+    QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>(layer);
+    if (!vl) continue;
+
+    QgsFeatureRequest req;
+    req.setDestinationCrs(rectCrs, transformContext);
+    req.setFilterRect(rect);
+    req.setFlags(Qgis::FeatureRequestFlag::ExactIntersect);
+
+    emscripten::val featuresArr = emscripten::val::array();
+    QgsFeatureIterator it = vl->getFeatures(req);
+    QgsFeature f;
+    while (it.nextFeature(f)) {
+      featuresArr.call<void>("push", Feature(f));
+    }
+    it.close();
+
+    if (featuresArr["length"].as<int>() == 0) continue;
+
+    emscripten::val result = emscripten::val::object();
+    result.set("layer", wrapLayer(vl));
+    result.set("features", featuresArr);
+    results.call<void>("push", result);
+
+    if (mode == 0 /* TopDownStopAtFirst */) break;
+  }
+
+  return results;
+}
+
 LayerDefinitionResult
 QgisApi_loadLayerDefinition(std::string path, std::optional<LayerTreeGroup> targetGroup) {
   QString errorMessage;
@@ -372,4 +420,5 @@ EMSCRIPTEN_BINDINGS(QgisApi) {
   emscripten::function("setProjectVariables", &QgisApi_setProjectVariables);
   emscripten::function("renderLegend", &QgisApi_renderLegend);
   emscripten::function("loadLayerDefinition", &QgisApi_loadLayerDefinition);
+  emscripten::function("identify", &QgisApi_identify);
 }

--- a/src/api/QgisApi.ts
+++ b/src/api/QgisApi.ts
@@ -5,6 +5,8 @@ import {
   QgsLayerTreeGroup,
 } from "./QgisModel";
 
+import type { IdentifyMode, IdentifyResult } from "./QgisIdentify";
+
 export interface LayerDefinitionResult {
   success: boolean;
   errorMessage: string;
@@ -151,6 +153,28 @@ export interface CommonQgisApi extends QgisModelConstructors {
     pixelRatio: number,
     layerIds?: string[],
   ): QgsMapRendererParallelJob;
+
+  /**
+   * Identifies vector features intersecting a rectangle, walking visible
+   * layers in top-down render order. Mirrors the core of QGIS's
+   * `QgsMapToolIdentify::identifyVectorLayer` without the GUI dependency.
+   *
+   * The rect is interpreted in `rectSrid`; per-layer queries reproject it
+   * into each layer's CRS. Returned feature geometries are in `rectSrid`.
+   *
+   * Uses provider spatial indexes (`setFilterRect`) + exact geometry
+   * intersection (`Qgis::FeatureRequestFlag::ExactIntersect`) — no
+   * full-layer scans.
+   *
+   * @param rect - The hit-box rectangle.
+   * @param rectSrid - SRID of the rectangle (e.g. the map's project CRS).
+   * @param mode - See {@link IdentifyMode}.
+   */
+  identify(
+    rect: QgsRectangle,
+    rectSrid: string,
+    mode: IdentifyMode,
+  ): IdentifyResult[];
 }
 
 /**

--- a/src/api/QgisApi.ts
+++ b/src/api/QgisApi.ts
@@ -162,9 +162,10 @@ export interface CommonQgisApi extends QgisModelConstructors {
    * The rect is interpreted in `rectSrid`; per-layer queries reproject it
    * into each layer's CRS. Returned feature geometries are in `rectSrid`.
    *
-   * Uses provider spatial indexes (`setFilterRect`) + exact geometry
-   * intersection (`Qgis::FeatureRequestFlag::ExactIntersect`) — no
-   * full-layer scans.
+   * Uses `setFilterRect` plus exact geometry intersection
+   * (`Qgis::FeatureRequestFlag::ExactIntersect`). When the data provider
+   * supports a spatial index, the rectangle hint lets it skip a full-layer
+   * scan; providers without an index will fall back to scanning.
    *
    * @param rect - The hit-box rectangle.
    * @param rectSrid - SRID of the rectangle (e.g. the map's project CRS).

--- a/src/api/QgisIdentify.ts
+++ b/src/api/QgisIdentify.ts
@@ -1,0 +1,26 @@
+import type { QgsFeature } from "../model/QgsFeature";
+import type { QgsMapLayer } from "../model/QgsMapLayer";
+
+/**
+ * Subset of `QgsMapToolIdentify::IdentifyMode` that's meaningful in a
+ * headless context. The GUI tool also has `ActiveLayer` and `LayerSelection`
+ * modes; those are out of scope here.
+ */
+export enum IdentifyMode {
+  /** Walk visible layers top-down, return after the first layer with hits. */
+  TopDownStopAtFirst = 0,
+  /** Walk all visible layers top-down, return every hit. */
+  TopDownAll = 1,
+}
+
+/**
+ * One vector layer's contribution to an identify result set.
+ *
+ * Slimmer than `QgsMapToolIdentify::IdentifyResult` — vector-only, no
+ * derived attributes, no per-layer label. The full `QgsFeature` is in
+ * `features` so callers can read attributes/geometry as usual.
+ */
+export interface IdentifyResult {
+  layer: QgsMapLayer;
+  features: QgsFeature[];
+}

--- a/src/api/QgisModel.ts
+++ b/src/api/QgisModel.ts
@@ -23,6 +23,14 @@ import type {
   QgsFeatureRequestConstructors,
 } from "../model/QgsFeatureRequest";
 import { FeatureRequestFlag } from "../model/QgsFeatureRequest";
+import type {
+  QgsExpression,
+  QgsExpressionConstructors,
+} from "../model/QgsExpression";
+import type {
+  QgsExpressionContext,
+  QgsExpressionContextConstructors,
+} from "../model/QgsExpressionContext";
 
 export type {
   QgsMapRendererJob,
@@ -42,6 +50,8 @@ export type {
   QgsFeature,
   QgsFeatureIterator,
   QgsFeatureRequest,
+  QgsExpression,
+  QgsExpressionContext,
 };
 
 export type { LayerDefinitionResult } from "./QgisApi";
@@ -56,5 +66,7 @@ export interface QgisModelConstructors
   extends
     QgsPointXYConstructors,
     QgsRectangleConstructors,
-    QgsFeatureRequestConstructors
+    QgsFeatureRequestConstructors,
+    QgsExpressionConstructors,
+    QgsExpressionContextConstructors
   {}

--- a/src/api/QgisModel.ts
+++ b/src/api/QgisModel.ts
@@ -13,6 +13,16 @@ import { LayerType } from "../model/QgsMapLayer";
 import type { QgsMapRendererParallelJob } from "../model/QgsMapRendererParallelJob";
 import type { QgsMapRendererJob } from "../model/QgsMapRendererJob";
 import type { QgsMapRendererQImageJob } from "../model/QgsMapRendererQImageJob";
+import type { QgsField } from "../model/QgsField";
+import type { QgsFields } from "../model/QgsFields";
+import type { QgsGeometry } from "../model/QgsGeometry";
+import type { QgsFeature } from "../model/QgsFeature";
+import type { QgsFeatureIterator } from "../model/QgsFeatureIterator";
+import type {
+  QgsFeatureRequest,
+  QgsFeatureRequestConstructors,
+} from "../model/QgsFeatureRequest";
+import { FeatureRequestFlag } from "../model/QgsFeatureRequest";
 
 export type {
   QgsMapRendererJob,
@@ -26,16 +36,25 @@ export type {
   QgsLayerTreeLayer,
   QgsMapLayer,
   QgsVectorLayer,
+  QgsField,
+  QgsFields,
+  QgsGeometry,
+  QgsFeature,
+  QgsFeatureIterator,
+  QgsFeatureRequest,
 };
 
 export type { LayerDefinitionResult } from "./QgisApi";
+export type { IdentifyResult } from "./QgisIdentify";
+export { IdentifyMode } from "./QgisIdentify";
 
-export { LayerType, NodeType };
+export { LayerType, NodeType, FeatureRequestFlag };
 
 /* prettier-ignore */
 
 export interface QgisModelConstructors
   extends
     QgsPointXYConstructors,
-    QgsRectangleConstructors
+    QgsRectangleConstructors,
+    QgsFeatureRequestConstructors
   {}

--- a/src/model/QVariant.hpp
+++ b/src/model/QVariant.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <QByteArray>
+#include <QDate>
+#include <QDateTime>
+#include <QMetaType>
+#include <QString>
+#include <QTime>
+#include <QVariant>
+
+#include <emscripten/bind.h>
+#include <emscripten/val.h>
+
+inline emscripten::val makeUint8Array(const char *data, int size) {
+  emscripten::val u8 = emscripten::val::global("Uint8Array").new_(size);
+  if (size > 0) {
+    emscripten::val view = emscripten::val(emscripten::typed_memory_view(
+      static_cast<size_t>(size), reinterpret_cast<const uint8_t *>(data)));
+    u8.call<void>("set", view);
+  }
+  return u8;
+}
+
+inline emscripten::val qvariantToVal(const QVariant &v) {
+  if (!v.isValid() || v.isNull()) return emscripten::val::null();
+
+  switch (v.userType()) {
+    case QMetaType::Bool:
+      return emscripten::val(v.toBool());
+    case QMetaType::Int:
+    case QMetaType::Short:
+      return emscripten::val(v.toInt());
+    case QMetaType::UInt:
+    case QMetaType::UShort:
+      return emscripten::val(v.toUInt());
+    case QMetaType::LongLong:
+    case QMetaType::ULongLong:
+      // JS numbers lose precision above 2^53; sufficient for typical FIDs and counts.
+      return emscripten::val(static_cast<double>(v.toLongLong()));
+    case QMetaType::Double:
+    case QMetaType::Float:
+      return emscripten::val(v.toDouble());
+    case QMetaType::QString:
+      return emscripten::val(v.toString().toStdString());
+    case QMetaType::QByteArray: {
+      QByteArray ba = v.toByteArray();
+      return makeUint8Array(ba.constData(), ba.size());
+    }
+    case QMetaType::QDateTime:
+      return emscripten::val(v.toDateTime().toString(Qt::ISODateWithMs).toStdString());
+    case QMetaType::QDate:
+      return emscripten::val(v.toDate().toString(Qt::ISODate).toStdString());
+    case QMetaType::QTime:
+      return emscripten::val(v.toTime().toString(Qt::ISODateWithMs).toStdString());
+    default:
+      return emscripten::val(v.toString().toStdString());
+  }
+}

--- a/src/model/QVariant.hpp
+++ b/src/model/QVariant.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include <QByteArray>
 #include <QDate>
 #include <QDateTime>
@@ -21,6 +23,20 @@ inline emscripten::val makeUint8Array(const char *data, int size) {
   return u8;
 }
 
+// Returns a JS Number when the value fits in the safe integer range, BigInt
+// otherwise. Avoids precision loss for 64-bit ints (FIDs, large counts, …).
+inline emscripten::val makeIntegerVal(long long value) {
+  constexpr long long SAFE = 1LL << 53;
+  if (value >= -SAFE && value <= SAFE) return emscripten::val(static_cast<double>(value));
+  return emscripten::val::global("BigInt")(emscripten::val(std::to_string(value)));
+}
+
+inline emscripten::val makeIntegerVal(unsigned long long value) {
+  constexpr unsigned long long SAFE = 1ULL << 53;
+  if (value <= SAFE) return emscripten::val(static_cast<double>(value));
+  return emscripten::val::global("BigInt")(emscripten::val(std::to_string(value)));
+}
+
 inline emscripten::val qvariantToVal(const QVariant &v) {
   if (!v.isValid() || v.isNull()) return emscripten::val::null();
 
@@ -34,9 +50,9 @@ inline emscripten::val qvariantToVal(const QVariant &v) {
     case QMetaType::UShort:
       return emscripten::val(v.toUInt());
     case QMetaType::LongLong:
+      return makeIntegerVal(static_cast<long long>(v.toLongLong()));
     case QMetaType::ULongLong:
-      // JS numbers lose precision above 2^53; sufficient for typical FIDs and counts.
-      return emscripten::val(static_cast<double>(v.toLongLong()));
+      return makeIntegerVal(static_cast<unsigned long long>(v.toULongLong()));
     case QMetaType::Double:
     case QMetaType::Float:
       return emscripten::val(v.toDouble());

--- a/src/model/QgsExpression.hpp
+++ b/src/model/QgsExpression.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <string>
+
+#include <qgsexpression.h>
+
+#include <emscripten/bind.h>
+#include <emscripten/val.h>
+
+#include "./QVariant.hpp"
+#include "./QgsExpressionContext.hpp"
+
+class Expression {
+public:
+  Expression() = default;
+  Expression(std::string expression) : _expr(QString::fromStdString(expression)) {}
+
+  static std::string replaceExpressionText(std::string text, const ExpressionContext &context) {
+    return QgsExpression::replaceExpressionText(
+             QString::fromStdString(text), &context.nativeContext())
+      .toStdString();
+  }
+
+  std::string expression() const {
+    return _expr.expression().toStdString();
+  }
+
+  bool isValid() const {
+    return _expr.isValid();
+  }
+
+  bool hasParserError() const {
+    return _expr.hasParserError();
+  }
+
+  std::string parserErrorString() const {
+    return _expr.parserErrorString().toStdString();
+  }
+
+  bool hasEvalError() const {
+    return _expr.hasEvalError();
+  }
+
+  std::string evalErrorString() const {
+    return _expr.evalErrorString().toStdString();
+  }
+
+  bool prepare(const ExpressionContext &context) {
+    return _expr.prepare(&context.nativeContext());
+  }
+
+  emscripten::val evaluate(const ExpressionContext &context) {
+    return qvariantToVal(_expr.evaluate(&context.nativeContext()));
+  }
+
+private:
+  QgsExpression _expr;
+};
+
+EMSCRIPTEN_BINDINGS(QgsExpression) {
+  emscripten::class_<Expression>("QgsExpression")
+    .constructor<std::string>()
+    .function("expression", &Expression::expression)
+    .function("isValid", &Expression::isValid)
+    .function("hasParserError", &Expression::hasParserError)
+    .function("parserErrorString", &Expression::parserErrorString)
+    .function("hasEvalError", &Expression::hasEvalError)
+    .function("evalErrorString", &Expression::evalErrorString)
+    .function("prepare", &Expression::prepare)
+    .function("evaluate", &Expression::evaluate)
+    .class_function("replaceExpressionText", &Expression::replaceExpressionText);
+}

--- a/src/model/QgsExpression.ts
+++ b/src/model/QgsExpression.ts
@@ -1,0 +1,39 @@
+import type { QgsExpressionContext } from "./QgsExpressionContext";
+
+/**
+ * Parses and evaluates a QGIS expression. Build a context (e.g. via
+ * `QgsVectorLayer.createExpressionContext()`, then `ctx.setFeature(f)`) and
+ * pass it to {@link evaluate} or {@link prepare}.
+ *
+ * {@link https://api.qgis.org/api/classQgsExpression.html}
+ */
+export interface QgsExpression {
+  expression(): string;
+  isValid(): boolean;
+  hasParserError(): boolean;
+  parserErrorString(): string;
+  hasEvalError(): boolean;
+  evalErrorString(): string;
+  /**
+   * Pre-compiles the expression for repeated evaluation. Returns false if
+   * the parser failed.
+   */
+  prepare(context: QgsExpressionContext): boolean;
+  /**
+   * Evaluates the expression in the given context. Check {@link hasEvalError}
+   * afterwards if needed.
+   */
+  evaluate(context: QgsExpressionContext): unknown;
+}
+
+export interface QgsExpressionConstructors {
+  QgsExpression: {
+    new (expression: string): QgsExpression;
+    /**
+     * Walks `text` and substitutes every `[% expr %]` placeholder with the
+     * result of evaluating that expression in `context`. The natural way to
+     * render a `QgsVectorLayer.mapTipTemplate()` for a feature.
+     */
+    replaceExpressionText(text: string, context: QgsExpressionContext): string;
+  };
+}

--- a/src/model/QgsExpressionContext.hpp
+++ b/src/model/QgsExpressionContext.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <string>
+
+#include <qgsexpressioncontext.h>
+
+#include <emscripten/bind.h>
+#include <emscripten/val.h>
+
+#include "./QVariant.hpp"
+#include "./QgsFeature.hpp"
+#include "./QgsFields.hpp"
+
+class ExpressionContext {
+public:
+  ExpressionContext() = default;
+  ExpressionContext(const QgsExpressionContext &ctx) : _ctx(ctx) {}
+
+  void setFeature(const Feature &feature) {
+    _ctx.setFeature(feature.nativeFeature());
+  }
+
+  void setFields(const Fields &fields) {
+    _ctx.setFields(fields.nativeFields());
+  }
+
+  emscripten::val variable(std::string name) const {
+    return qvariantToVal(_ctx.variable(QString::fromStdString(name)));
+  }
+
+  const QgsExpressionContext &nativeContext() const {
+    return _ctx;
+  }
+
+  QgsExpressionContext &nativeContext() {
+    return _ctx;
+  }
+
+private:
+  QgsExpressionContext _ctx;
+};
+
+EMSCRIPTEN_BINDINGS(QgsExpressionContext) {
+  emscripten::class_<ExpressionContext>("QgsExpressionContext")
+    .constructor<>()
+    .function("setFeature", &ExpressionContext::setFeature)
+    .function("setFields", &ExpressionContext::setFields)
+    .function("variable", &ExpressionContext::variable);
+}

--- a/src/model/QgsExpressionContext.ts
+++ b/src/model/QgsExpressionContext.ts
@@ -1,0 +1,19 @@
+import type { QgsFeature } from "./QgsFeature";
+import type { QgsFields } from "./QgsFields";
+
+/**
+ * The scope stack that an expression sees during evaluation. Typically built
+ * by `QgsVectorLayer.createExpressionContext()` which stacks the standard
+ * global → project → layer scopes and sets the layer's fields.
+ *
+ * {@link https://api.qgis.org/api/classQgsExpressionContext.html}
+ */
+export interface QgsExpressionContext {
+  setFeature(feature: QgsFeature): void;
+  setFields(fields: QgsFields): void;
+  variable(name: string): unknown;
+}
+
+export interface QgsExpressionContextConstructors {
+  QgsExpressionContext: { new (): QgsExpressionContext };
+}

--- a/src/model/QgsFeature.hpp
+++ b/src/model/QgsFeature.hpp
@@ -49,6 +49,10 @@ public:
     return result;
   }
 
+  const QgsFeature &nativeFeature() const {
+    return _feature;
+  }
+
   emscripten::val attribute(emscripten::val nameOrIndex) const {
     if (nameOrIndex.isNumber()) {
       int idx = nameOrIndex.as<int>();

--- a/src/model/QgsFeature.hpp
+++ b/src/model/QgsFeature.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <string>
+
+#include <qgsfeature.h>
+
+#include <emscripten/bind.h>
+#include <emscripten/val.h>
+
+#include "./QVariant.hpp"
+#include "./QgsFields.hpp"
+#include "./QgsGeometry.hpp"
+
+class Feature {
+public:
+  Feature() = default;
+  Feature(const QgsFeature &feature) : _feature(feature) {}
+
+  double id() const {
+    return static_cast<double>(_feature.id());
+  }
+
+  bool isValid() const {
+    return _feature.isValid();
+  }
+
+  bool hasGeometry() const {
+    return _feature.hasGeometry();
+  }
+
+  Geometry geometry() const {
+    return Geometry(_feature.geometry());
+  }
+
+  Fields fields() const {
+    return Fields(_feature.fields());
+  }
+
+  int attributeCount() const {
+    return _feature.attributeCount();
+  }
+
+  emscripten::val attributes() const {
+    emscripten::val result = emscripten::val::array();
+    const QgsAttributes attrs = _feature.attributes();
+    for (const QVariant &v : attrs) {
+      result.call<void>("push", qvariantToVal(v));
+    }
+    return result;
+  }
+
+  emscripten::val attribute(emscripten::val nameOrIndex) const {
+    if (nameOrIndex.isNumber()) {
+      int idx = nameOrIndex.as<int>();
+      if (idx < 0 || idx >= _feature.attributeCount()) return emscripten::val::null();
+      return qvariantToVal(_feature.attribute(idx));
+    }
+    if (nameOrIndex.isString()) {
+      std::string name = nameOrIndex.as<std::string>();
+      QVariant v = _feature.attribute(QString::fromStdString(name));
+      return qvariantToVal(v);
+    }
+    return emscripten::val::null();
+  }
+
+private:
+  QgsFeature _feature;
+};
+
+EMSCRIPTEN_BINDINGS(QgsFeature) {
+  emscripten::class_<Feature>("QgsFeature")
+    .constructor<>()
+    .function("id", &Feature::id)
+    .function("isValid", &Feature::isValid)
+    .function("hasGeometry", &Feature::hasGeometry)
+    .function("geometry", &Feature::geometry)
+    .function("fields", &Feature::fields)
+    .function("attributeCount", &Feature::attributeCount)
+    .function("attributes", &Feature::attributes)
+    .function("attribute", &Feature::attribute);
+}

--- a/src/model/QgsFeature.ts
+++ b/src/model/QgsFeature.ts
@@ -22,5 +22,5 @@ export interface QgsFeature {
    * Single attribute value by field name or zero-based index. Returns null
    * when the field is unknown or the value is null.
    */
-  attribute(nameOrIndex: string | number): unknown;
+  attribute(nameOrIndex: string | number): unknown | null;
 }

--- a/src/model/QgsFeature.ts
+++ b/src/model/QgsFeature.ts
@@ -1,0 +1,26 @@
+import type { QgsFields } from "./QgsFields";
+import type { QgsGeometry } from "./QgsGeometry";
+
+/**
+ * A single feature: an id, a geometry, and an ordered list of attribute values.
+ *
+ * {@link https://api.qgis.org/api/classQgsFeature.html}
+ */
+export interface QgsFeature {
+  id(): number;
+  isValid(): boolean;
+  hasGeometry(): boolean;
+  geometry(): QgsGeometry;
+  fields(): QgsFields;
+  attributeCount(): number;
+  /**
+   * All attribute values in field order. Scalar values are converted to JS
+   * primitives via QVariant; geometry is NOT included.
+   */
+  attributes(): unknown[];
+  /**
+   * Single attribute value by field name or zero-based index. Returns null
+   * when the field is unknown or the value is null.
+   */
+  attribute(nameOrIndex: string | number): unknown;
+}

--- a/src/model/QgsFeatureIterator.hpp
+++ b/src/model/QgsFeatureIterator.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <qgsfeatureiterator.h>
+
+#include <emscripten/bind.h>
+#include <emscripten/val.h>
+
+#include "./QgsFeature.hpp"
+
+class FeatureIterator {
+public:
+  FeatureIterator() = default;
+  FeatureIterator(const QgsFeatureIterator &it) : _it(it) {}
+
+  emscripten::val nextFeature() {
+    QgsFeature f;
+    if (_it.nextFeature(f)) {
+      return emscripten::val(Feature(f));
+    }
+    return emscripten::val::null();
+  }
+
+  bool rewind() {
+    return _it.rewind();
+  }
+
+  bool close() {
+    return _it.close();
+  }
+
+  bool isClosed() const {
+    return _it.isClosed();
+  }
+
+  bool isValid() const {
+    return _it.isValid();
+  }
+
+private:
+  QgsFeatureIterator _it;
+};
+
+EMSCRIPTEN_BINDINGS(QgsFeatureIterator) {
+  emscripten::class_<FeatureIterator>("QgsFeatureIterator")
+    .constructor<>()
+    .function("nextFeature", &FeatureIterator::nextFeature)
+    .function("rewind", &FeatureIterator::rewind)
+    .function("close", &FeatureIterator::close)
+    .function("isClosed", &FeatureIterator::isClosed)
+    .function("isValid", &FeatureIterator::isValid);
+}

--- a/src/model/QgsFeatureIterator.ts
+++ b/src/model/QgsFeatureIterator.ts
@@ -1,0 +1,23 @@
+import type { QgsFeature } from "./QgsFeature";
+
+/**
+ * Iterates features pulled lazily from a vector layer (or its data provider).
+ * Hold an iterator open across calls to read large layers without
+ * materializing all features at once.
+ *
+ * Differs from the C++ API in that {@link nextFeature} returns the feature
+ * value (or null when exhausted) rather than mutating an out-parameter and
+ * returning a boolean — that pattern doesn't translate to JS.
+ *
+ * Callers should {@link close} the iterator when done. Reaching the end
+ * (`nextFeature() === null`) closes it implicitly inside QGIS.
+ *
+ * {@link https://api.qgis.org/api/classQgsFeatureIterator.html}
+ */
+export interface QgsFeatureIterator {
+  nextFeature(): QgsFeature | null;
+  rewind(): boolean;
+  close(): boolean;
+  isClosed(): boolean;
+  isValid(): boolean;
+}

--- a/src/model/QgsFeatureRequest.hpp
+++ b/src/model/QgsFeatureRequest.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <string>
+
+#include <qgis.h>
+#include <qgscoordinatereferencesystem.h>
+#include <qgsfeaturerequest.h>
+#include <qgsfields.h>
+#include <qgsproject.h>
+#include <qgsrectangle.h>
+
+#include <emscripten/bind.h>
+#include <emscripten/val.h>
+
+#include "./QgsFields.hpp"
+
+class FeatureRequest {
+public:
+  FeatureRequest() = default;
+  FeatureRequest(const QgsFeatureRequest &request) : _request(request) {}
+
+  void setFilterRect(const QgsRectangle &rectangle) {
+    _request.setFilterRect(rectangle);
+  }
+
+  void setFilterExpression(std::string expression) {
+    _request.setFilterExpression(QString::fromStdString(expression));
+  }
+
+  void setFilterFid(double fid) {
+    _request.setFilterFid(static_cast<QgsFeatureId>(fid));
+  }
+
+  void setFilterFids(emscripten::val fids) {
+    QgsFeatureIds ids;
+    int length = fids["length"].as<int>();
+    for (int i = 0; i < length; ++i) {
+      ids.insert(static_cast<QgsFeatureId>(fids[i].as<double>()));
+    }
+    _request.setFilterFids(ids);
+  }
+
+  void setLimit(double limit) {
+    _request.setLimit(static_cast<long long>(limit));
+  }
+
+  void setFlags(int flags) {
+    _request.setFlags(static_cast<Qgis::FeatureRequestFlags>(flags));
+  }
+
+  int flags() const {
+    return static_cast<int>(_request.flags());
+  }
+
+  void setSubsetOfAttributes(emscripten::val names, const Fields &fields) {
+    QStringList list;
+    int length = names["length"].as<int>();
+    for (int i = 0; i < length; ++i) {
+      list << QString::fromStdString(names[i].as<std::string>());
+    }
+    _request.setSubsetOfAttributes(list, fields.nativeFields());
+  }
+
+  void setDestinationCrs(std::string authid) {
+    _request.setDestinationCrs(
+      QgsCoordinateReferenceSystem(QString::fromStdString(authid)),
+      QgsProject::instance()->transformContext());
+  }
+
+  const QgsFeatureRequest &nativeRequest() const {
+    return _request;
+  }
+
+private:
+  QgsFeatureRequest _request;
+};
+
+EMSCRIPTEN_BINDINGS(QgsFeatureRequest) {
+  emscripten::class_<FeatureRequest>("QgsFeatureRequest")
+    .constructor<>()
+    .function("setFilterRect", &FeatureRequest::setFilterRect)
+    .function("setFilterExpression", &FeatureRequest::setFilterExpression)
+    .function("setFilterFid", &FeatureRequest::setFilterFid)
+    .function("setFilterFids", &FeatureRequest::setFilterFids)
+    .function("setLimit", &FeatureRequest::setLimit)
+    .function("setFlags", &FeatureRequest::setFlags)
+    .function("flags", &FeatureRequest::flags)
+    .function("setSubsetOfAttributes", &FeatureRequest::setSubsetOfAttributes)
+    .function("setDestinationCrs", &FeatureRequest::setDestinationCrs);
+
+  emscripten::register_optional<FeatureRequest>();
+}

--- a/src/model/QgsFeatureRequest.ts
+++ b/src/model/QgsFeatureRequest.ts
@@ -1,0 +1,47 @@
+import type { QgsFields } from "./QgsFields";
+import type { QgsRectangle } from "./QgsRectangle";
+
+/**
+ * Mirrors `Qgis::FeatureRequestFlag`. Values are bit flags and can be
+ * combined with `|` before passing to {@link QgsFeatureRequest.setFlags}.
+ *
+ * {@link https://api.qgis.org/api/classQgis.html}
+ */
+export enum FeatureRequestFlag {
+  NoFlags = 0,
+  NoGeometry = 1,
+  SubsetOfAttributes = 2,
+  ExactIntersect = 4,
+  IgnoreStaticNodesDuringExpressionCompilation = 8,
+  EmbeddedSymbols = 16,
+}
+
+/**
+ * A request describing which features to fetch from a vector layer:
+ * spatial filter, attribute filter, fid filter, limit, and flags.
+ *
+ * {@link https://api.qgis.org/api/classQgsFeatureRequest.html}
+ */
+export interface QgsFeatureRequest {
+  setFilterRect(rect: QgsRectangle): void;
+  setFilterExpression(expression: string): void;
+  setFilterFid(fid: number): void;
+  setFilterFids(fids: number[]): void;
+  setLimit(limit: number): void;
+  /**
+   * Combine {@link FeatureRequestFlag} values with `|` to build the bitmask.
+   */
+  setFlags(flags: number): void;
+  flags(): number;
+  setSubsetOfAttributes(names: string[], fields: QgsFields): void;
+  /**
+   * When set, the filter rect is interpreted in this CRS and returned
+   * geometries are reprojected from the layer's source CRS into it.
+   * @param authid SRID such as `"EPSG:3857"`.
+   */
+  setDestinationCrs(authid: string): void;
+}
+
+export interface QgsFeatureRequestConstructors {
+  QgsFeatureRequest: { new (): QgsFeatureRequest };
+}

--- a/src/model/QgsField.hpp
+++ b/src/model/QgsField.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <string>
+
+#include <qgsfield.h>
+
+#include <emscripten/bind.h>
+
+class Field {
+public:
+  Field() = default;
+  Field(const QgsField &field) : _field(field) {}
+
+  std::string name() const {
+    return _field.name().toStdString();
+  }
+
+  std::string typeName() const {
+    return _field.typeName().toStdString();
+  }
+
+  int type() const {
+    return static_cast<int>(_field.type());
+  }
+
+  std::string alias() const {
+    return _field.alias().toStdString();
+  }
+
+  int length() const {
+    return _field.length();
+  }
+
+  int precision() const {
+    return _field.precision();
+  }
+
+  const QgsField &nativeField() const {
+    return _field;
+  }
+
+private:
+  QgsField _field;
+};
+
+EMSCRIPTEN_BINDINGS(QgsField) {
+  emscripten::class_<Field>("QgsField")
+    .constructor<>()
+    .function("name", &Field::name)
+    .function("typeName", &Field::typeName)
+    .function("type", &Field::type)
+    .function("alias", &Field::alias)
+    .function("length", &Field::length)
+    .function("precision", &Field::precision);
+}

--- a/src/model/QgsField.ts
+++ b/src/model/QgsField.ts
@@ -1,0 +1,16 @@
+/**
+ * Encapsulates a field's metadata: name, type, length, precision.
+ *
+ * {@link https://api.qgis.org/api/classQgsField.html}
+ */
+export interface QgsField {
+  name(): string;
+  typeName(): string;
+  /**
+   * QMetaType::Type enum value.
+   */
+  type(): number;
+  alias(): string;
+  length(): number;
+  precision(): number;
+}

--- a/src/model/QgsFields.hpp
+++ b/src/model/QgsFields.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <string>
+
+#include <qgsfields.h>
+
+#include <emscripten/bind.h>
+#include <emscripten/val.h>
+
+#include "./QgsField.hpp"
+
+class Fields {
+public:
+  Fields() = default;
+  Fields(const QgsFields &fields) : _fields(fields) {}
+
+  int count() const {
+    return _fields.count();
+  }
+
+  Field at(int index) const {
+    if (index < 0 || index >= _fields.count()) return Field();
+    return Field(_fields.at(index));
+  }
+
+  emscripten::val field(std::string name) const {
+    int idx = _fields.lookupField(QString::fromStdString(name));
+    if (idx < 0) return emscripten::val::null();
+    return emscripten::val(Field(_fields.at(idx)));
+  }
+
+  const QgsFields &nativeFields() const {
+    return _fields;
+  }
+
+private:
+  QgsFields _fields;
+};
+
+EMSCRIPTEN_BINDINGS(QgsFields) {
+  emscripten::class_<Fields>("QgsFields")
+    .constructor<>()
+    .function("count", &Fields::count)
+    .function("at", &Fields::at)
+    .function("field", &Fields::field);
+}

--- a/src/model/QgsFields.ts
+++ b/src/model/QgsFields.ts
@@ -1,0 +1,15 @@
+import type { QgsField } from "./QgsField";
+
+/**
+ * Container of fields for a vector layer or feature.
+ *
+ * {@link https://api.qgis.org/api/classQgsFields.html}
+ */
+export interface QgsFields {
+  count(): number;
+  at(index: number): QgsField;
+  /**
+   * Lookup a field by name. Returns null if no field with that name exists.
+   */
+  field(name: string): QgsField | null;
+}

--- a/src/model/QgsGeometry.hpp
+++ b/src/model/QgsGeometry.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <string>
+
+#include <qgsgeometry.h>
+
+#include <emscripten/bind.h>
+#include <emscripten/val.h>
+
+#include "./QVariant.hpp"
+
+class Geometry {
+public:
+  Geometry() = default;
+  Geometry(const QgsGeometry &geometry) : _geometry(geometry) {}
+
+  bool isNull() const {
+    return _geometry.isNull();
+  }
+
+  bool isEmpty() const {
+    return _geometry.isEmpty();
+  }
+
+  int wkbType() const {
+    return static_cast<int>(_geometry.wkbType());
+  }
+
+  emscripten::val asWkb() const {
+    QByteArray wkb = _geometry.asWkb();
+    return makeUint8Array(wkb.constData(), wkb.size());
+  }
+
+  std::string asWkt(int precision) const {
+    return _geometry.asWkt(precision).toStdString();
+  }
+
+  std::string asJson(int precision) const {
+    return _geometry.asJson(precision).toStdString();
+  }
+
+private:
+  QgsGeometry _geometry;
+};
+
+EMSCRIPTEN_BINDINGS(QgsGeometry) {
+  emscripten::class_<Geometry>("QgsGeometry")
+    .constructor<>()
+    .function("isNull", &Geometry::isNull)
+    .function("isEmpty", &Geometry::isEmpty)
+    .function("wkbType", &Geometry::wkbType)
+    .function("asWkb", &Geometry::asWkb)
+    .function("asWkt", &Geometry::asWkt)
+    .function("asJson", &Geometry::asJson);
+}

--- a/src/model/QgsGeometry.ts
+++ b/src/model/QgsGeometry.ts
@@ -1,0 +1,30 @@
+/**
+ * A geometry, mirroring the QGIS QgsGeometry value type. Use {@link asWkb},
+ * {@link asWkt}, or {@link asJson} to serialize for consumption in JS (e.g.
+ * `ol/format/WKB` in OpenLayers).
+ *
+ * {@link https://api.qgis.org/api/classQgsGeometry.html}
+ */
+export interface QgsGeometry {
+  isNull(): boolean;
+  isEmpty(): boolean;
+  /**
+   * The Qgis::WkbType enum value of the geometry.
+   */
+  wkbType(): number;
+  /**
+   * Well-Known Binary representation. Owned Uint8Array safe to keep across calls.
+   */
+  asWkb(): Uint8Array;
+  /**
+   * Well-Known Text representation.
+   * @param precision number of decimal places for coordinate values (QGIS default is 17).
+   */
+  asWkt(precision: number): string;
+  /**
+   * GeoJSON geometry string (not a Feature). Call `JSON.parse` on the result for
+   * an object literal.
+   * @param precision number of decimal places for coordinate values (QGIS default is 17).
+   */
+  asJson(precision: number): string;
+}

--- a/src/model/QgsMapLayer.hpp
+++ b/src/model/QgsMapLayer.hpp
@@ -3,12 +3,16 @@
 #include <optional>
 #include <string>
 
+#include <qgsexpressioncontext.h>
+#include <qgsexpressioncontextutils.h>
 #include <qgsmaplayer.h>
+#include <qgsproject.h>
 #include <qgsvectorlayer.h>
 
 #include <emscripten/bind.h>
 #include <emscripten/val.h>
 
+#include "./QgsExpressionContext.hpp"
 #include "./QgsFeatureIterator.hpp"
 #include "./QgsFeatureRequest.hpp"
 #include "./QgsFields.hpp"
@@ -98,6 +102,25 @@ public:
     return FeatureIterator(vl->getFeatures());
   }
 
+  std::string displayExpression() const {
+    if (auto *vl = asVectorLayer()) return vl->displayExpression().toStdString();
+    return "";
+  }
+
+  std::string mapTipTemplate() const {
+    if (auto *vl = asVectorLayer()) return vl->mapTipTemplate().toStdString();
+    return "";
+  }
+
+  ExpressionContext createExpressionContext() const {
+    auto *vl = asVectorLayer();
+    if (!vl) return ExpressionContext();
+    QgsExpressionContext ctx = QgsProject::instance()->createExpressionContext();
+    ctx << QgsExpressionContextUtils::layerScope(vl);
+    ctx.setFields(vl->fields());
+    return ExpressionContext(ctx);
+  }
+
 private:
   QgsVectorLayer *asVectorLayer() const {
     if (!_layer) return nullptr;
@@ -128,5 +151,8 @@ EMSCRIPTEN_BINDINGS(QgsMapLayer) {
     .function("setSubsetString", &VectorLayer::setSubsetString)
     .function("featureCount", &VectorLayer::featureCount)
     .function("fields", &VectorLayer::fields)
-    .function("getFeatures", &VectorLayer::getFeatures);
+    .function("getFeatures", &VectorLayer::getFeatures)
+    .function("displayExpression", &VectorLayer::displayExpression)
+    .function("mapTipTemplate", &VectorLayer::mapTipTemplate)
+    .function("createExpressionContext", &VectorLayer::createExpressionContext);
 }

--- a/src/model/QgsMapLayer.hpp
+++ b/src/model/QgsMapLayer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <string>
 
 #include <qgsmaplayer.h>
@@ -7,6 +8,10 @@
 
 #include <emscripten/bind.h>
 #include <emscripten/val.h>
+
+#include "./QgsFeatureIterator.hpp"
+#include "./QgsFeatureRequest.hpp"
+#include "./QgsFields.hpp"
 
 class VectorLayer;
 
@@ -50,6 +55,11 @@ public:
     if (_layer) _layer->setOpacity(opacity);
   }
 
+  std::string crs() const {
+    if (!_layer) return "";
+    return _layer->crs().authid().toStdString();
+  }
+
 protected:
   QgsMapLayer *_layer;
 };
@@ -69,9 +79,29 @@ public:
     return false;
   }
 
+  double featureCount() const {
+    if (auto *vl = asVectorLayer()) return static_cast<double>(vl->featureCount());
+    return 0;
+  }
+
+  Fields fields() const {
+    if (auto *vl = asVectorLayer()) return Fields(vl->fields());
+    return Fields();
+  }
+
+  FeatureIterator getFeatures(std::optional<FeatureRequest> request) const {
+    auto *vl = asVectorLayer();
+    if (!vl) return FeatureIterator();
+    if (request.has_value()) {
+      return FeatureIterator(vl->getFeatures(request->nativeRequest()));
+    }
+    return FeatureIterator(vl->getFeatures());
+  }
+
 private:
   QgsVectorLayer *asVectorLayer() const {
-    Q_ASSERT(_layer && _layer->type() == Qgis::LayerType::Vector);
+    if (!_layer) return nullptr;
+    Q_ASSERT(_layer->type() == Qgis::LayerType::Vector);
     return static_cast<QgsVectorLayer *>(_layer);
   }
 };
@@ -89,10 +119,14 @@ EMSCRIPTEN_BINDINGS(QgsMapLayer) {
     .function("isValid", &MapLayer::isValid)
     .function("type", &MapLayer::type)
     .function("id", &MapLayer::id)
+    .function("crs", &MapLayer::crs)
     .property("name", &MapLayer::name, &MapLayer::setName)
     .property("opacity", &MapLayer::opacity, &MapLayer::setOpacity);
 
   emscripten::class_<VectorLayer, emscripten::base<MapLayer>>("QgsVectorLayer")
     .function("subsetString", &VectorLayer::subsetString)
-    .function("setSubsetString", &VectorLayer::setSubsetString);
+    .function("setSubsetString", &VectorLayer::setSubsetString)
+    .function("featureCount", &VectorLayer::featureCount)
+    .function("fields", &VectorLayer::fields)
+    .function("getFeatures", &VectorLayer::getFeatures);
 }

--- a/src/model/QgsMapLayer.ts
+++ b/src/model/QgsMapLayer.ts
@@ -1,3 +1,4 @@
+import type { QgsExpressionContext } from "./QgsExpressionContext";
 import type { QgsFeatureIterator } from "./QgsFeatureIterator";
 import type { QgsFeatureRequest } from "./QgsFeatureRequest";
 import type { QgsFields } from "./QgsFields";
@@ -36,4 +37,14 @@ export interface QgsVectorLayer extends QgsMapLayer {
   featureCount(): number;
   fields(): QgsFields;
   getFeatures(request?: QgsFeatureRequest): QgsFeatureIterator;
+  /** The configured display expression (e.g. `"name"`). Empty if none. */
+  displayExpression(): string;
+  /** The HTML map-tip template, which may contain `[% expr %]` placeholders. Empty if none. */
+  mapTipTemplate(): string;
+  /**
+   * Builds an expression context with the standard scopes stacked
+   * (global → project → layer) and the layer's fields set. Call
+   * `setFeature(feature)` on the result before passing to an expression.
+   */
+  createExpressionContext(): QgsExpressionContext;
 }

--- a/src/model/QgsMapLayer.ts
+++ b/src/model/QgsMapLayer.ts
@@ -23,7 +23,9 @@ export interface QgsMapLayer {
   id(): string;
   /**
    * The authid of the layer's source CRS (e.g. `"EPSG:4326"`). Geometries
-   * returned by features are expressed in this CRS.
+   * returned by features are expressed in this CRS unless the request used
+   * to fetch them sets a different destination CRS via
+   * `QgsFeatureRequest.setDestinationCrs()`.
    */
   crs(): string;
 }

--- a/src/model/QgsMapLayer.ts
+++ b/src/model/QgsMapLayer.ts
@@ -1,3 +1,7 @@
+import type { QgsFeatureIterator } from "./QgsFeatureIterator";
+import type { QgsFeatureRequest } from "./QgsFeatureRequest";
+import type { QgsFields } from "./QgsFields";
+
 export enum LayerType {
   Vector = 0,
   Raster = 1,
@@ -17,9 +21,17 @@ export interface QgsMapLayer {
   isValid(): boolean;
   type(): LayerType;
   id(): string;
+  /**
+   * The authid of the layer's source CRS (e.g. `"EPSG:4326"`). Geometries
+   * returned by features are expressed in this CRS.
+   */
+  crs(): string;
 }
 
 export interface QgsVectorLayer extends QgsMapLayer {
   subsetString(): string;
   setSubsetString(subset: string): boolean;
+  featureCount(): number;
+  fields(): QgsFields;
+  getFeatures(request?: QgsFeatureRequest): QgsFeatureIterator;
 }


### PR DESCRIPTION
# API additions
- Added feature inspection API: `QgsFeature`, `QgsGeometry`, `QgsField`/`QgsFields`, `QgsFeatureIterator`, `QgsFeatureRequest` (with `FeatureRequestFlag`). `QgsVectorLayer` gains `featureCount()`, `fields()`, `getFeatures(request?)`; `QgsMapLayer` gains `crs()`
- Added expression API: `QgsExpression`, `QgsExpressionContext`; `QgsVectorLayer` gains `displayExpression()`, `mapTipTemplate()`, `createExpressionContext()`
- Added cross-layer vector identify: `api.identify(rect, rectSrid, mode)` with an `IdentifyMode` enum
## Fixes
- Fixes #14 
## Example
<img width="2786" height="2342" alt="Screenshot from 2026-05-14 22-44-01" src="https://github.com/user-attachments/assets/6c359009-e350-4636-975a-b23b76566680" />

- see [`docs/examples/qgis-js-example-features`](https://github.com/qgis/qgis-js/tree/main/docs/examples/qgis-js-example-features)